### PR TITLE
Replace succeeding() by completing()

### DIFF
--- a/reactiverse-junit5-web-client-rx-java/src/test/java/io/reactiverse/junit5/web/rxjava/WebClientCustomOptionInjection.java
+++ b/reactiverse-junit5-web-client-rx-java/src/test/java/io/reactiverse/junit5/web/rxjava/WebClientCustomOptionInjection.java
@@ -34,10 +34,9 @@ public class WebClientCustomOptionInjection {
   void test(Vertx vertx, VertxTestContext testContext, WebClient client) {
     vertx.createHttpServer().requestHandler(req -> {
       req.response().end();
-      testContext.completeNow();
-    }).listen(9001, h -> {
-      client.get("/bla").send(testContext.succeeding());
-    });
+    }).listen(9001, testContext.succeeding(httpServer -> {
+      client.get("/bla").send(testContext.completing());
+    }));
   }
 
 }

--- a/reactiverse-junit5-web-client-rx-java2/src/test/java/io/reactiverse/junit5/web/rxjava2/WebClientCustomOptionInjection.java
+++ b/reactiverse-junit5-web-client-rx-java2/src/test/java/io/reactiverse/junit5/web/rxjava2/WebClientCustomOptionInjection.java
@@ -34,10 +34,9 @@ public class WebClientCustomOptionInjection {
   void test(Vertx vertx, VertxTestContext testContext, WebClient client) {
     vertx.createHttpServer().requestHandler(req -> {
       req.response().end();
-      testContext.completeNow();
-    }).listen(9001, h -> {
-      client.get("/bla").send(testContext.succeeding());
-    });
+    }).listen(9001, testContext.succeeding(httpServer -> {
+      client.get("/bla").send(testContext.completing());
+    }));
   }
 
 }

--- a/reactiverse-junit5-web-client/src/test/java/io/reactiverse/junit5/web/WebClientCustomOptionInjection.java
+++ b/reactiverse-junit5-web-client/src/test/java/io/reactiverse/junit5/web/WebClientCustomOptionInjection.java
@@ -33,10 +33,9 @@ public class WebClientCustomOptionInjection {
   void test(Vertx vertx, VertxTestContext testContext, WebClient client) {
     vertx.createHttpServer().requestHandler(req -> {
       req.response().end();
-      testContext.completeNow();
-    }).listen(9001, h -> {
-      client.get("/bla").send(testContext.succeeding());
-    });
+    }).listen(9001, testContext.succeeding(httpServer -> {
+      client.get("/bla").send(testContext.completing());
+    }));
   }
 
 }


### PR DESCRIPTION
Fix incorrect usage of succeeding(), use succeeding(v -> block) and completing() to fully test all responses.